### PR TITLE
Fix issue with payloads when using Krill on Java 8

### DIFF
--- a/src/main/java/de/ids_mannheim/korap/index/MultiTerm.java
+++ b/src/main/java/de/ids_mannheim/korap/index/MultiTerm.java
@@ -390,7 +390,7 @@ public class MultiTerm implements Comparable<MultiTerm> {
                 bb.rewind();
 
                 // Split payload at type marker boundaries
-                String[] pls = payloadStr.split("(?=<)|(?<=>)");
+                String[] pls = payloadStr.split("((?=<)|(?<=>))(?!\\A)");
 
                 l = 0; // Bytearray length
 
@@ -404,21 +404,21 @@ public class MultiTerm implements Comparable<MultiTerm> {
                             bb.position(l);
                         };
 
-                        switch (pls[i]) {
+                        switch (pls[i-1]) {
                             case "<b>": // byte
-                                bb.put(Byte.parseByte(pls[i + 1]));
+                                bb.put(Byte.parseByte(pls[i]));
                                 l++;
                                 break;
                             case "<s>": // short
-                                bb.putShort(Short.parseShort(pls[i + 1]));
+                                bb.putShort(Short.parseShort(pls[i]));
                                 l += 2;
                                 break;
                             case "<i>": // integer
-                                bb.putInt(Integer.parseInt(pls[i + 1]));
+                                bb.putInt(Integer.parseInt(pls[i]));
                                 l += 4;
                                 break;
                             case "<l>": // long
-                                bb.putLong(Long.parseLong(pls[i + 1]));
+                                bb.putLong(Long.parseLong(pls[i]));
                                 l += 8;
                                 break;
                         };


### PR DESCRIPTION
The current master branch won't successfully execute the tests and will be unable to perform searches if Krill is executed on a Java 8 VM. 

This seems to be related to a change in the semantics of splitting on empty strings which is explained in more detail in http://stackoverflow.com/a/27477312. The current code expects an empty string at the beginning of the array and skips it by using a static offset in the index. This pull request changes the RegEx so that both under Java 7 and Java 8 there is no empty string as first element in the splitted string. It also changes the indexes used to access the data to reflect the changes made to the RegEx.

I executed all tests cases both under OpenJDK 7 and OpenJDK 8 (both on Ubuntu Linux) and all test-cases succeed with these changes.